### PR TITLE
Null protection

### DIFF
--- a/karaf-packaging/src/main/scala/wav/devtools/karaf/packaging/ArtifactUtil.scala
+++ b/karaf-packaging/src/main/scala/wav/devtools/karaf/packaging/ArtifactUtil.scala
@@ -7,12 +7,19 @@ import scala.xml.XML
 
 private [devtools] object ArtifactUtil {
 
-  def getSymbolicName(file: File): Option[String] =
-    Option(
-      Util.getJarManifest(file)
-        .getMainAttributes
-        .getValue("Bundle-SymbolicName")
-    ).filterNot(_.isEmpty)
+  def getSymbolicName(file: File): Option[String] = {
+    if (file==null) None else {
+      val mf = Util.getJarManifest(file)
+      if (mf==null) None else
+      if (mf.getMainAttributes==null) None
+      else {
+        val sym = mf.getMainAttributes.getValue("Bundle-SymbolicName")
+        if (sym==null) None else {
+          Some(sym).filterNot(_.isEmpty)
+        }
+      }
+    }
+  }
 
   def isValidFeaturesXml(file: File): Boolean =
     if (!file.exists()) false

--- a/karaf-packaging/src/main/scala/wav/devtools/karaf/packaging/FeaturesXml.scala
+++ b/karaf-packaging/src/main/scala/wav/devtools/karaf/packaging/FeaturesXml.scala
@@ -109,7 +109,9 @@ object FeaturesXml {
       var v: Version = null
       try { v = Version.parseVersion(version) } catch {
         case ex: IllegalArgumentException => {
-          v = Version.parseVersion(version.replaceAll("[^0-9^.]",""))
+          val newVersion = version.replaceAll("[^0-9^.]","")
+          println(s"Exception: Version for $name and $version changed to $newVersion so that it will parse correctly with Version.parseVersion")
+          v = Version.parseVersion(newVersion)
         }
       }
       v

--- a/karaf-packaging/src/main/scala/wav/devtools/karaf/packaging/FeaturesXml.scala
+++ b/karaf-packaging/src/main/scala/wav/devtools/karaf/packaging/FeaturesXml.scala
@@ -104,8 +104,18 @@ object FeaturesXml {
 
   val emptyConditional = Conditional(null, Set.empty)
 
-  def feature(name: String, version: String, deps: Set[FeatureOption] = Set.empty): Feature =
-    Feature(name, Version.parseVersion(version), deps)
+  def feature(name: String, version: String, deps: Set[FeatureOption] = Set.empty): Feature = {
+    val versionResult: Version = {
+      var v: Version = null
+      try { v = Version.parseVersion(version) } catch {
+        case ex: IllegalArgumentException => {
+          v = Version.parseVersion(version.replaceAll("[^0-9^.]",""))
+        }
+      }
+      v
+    }
+    Feature(name, versionResult, deps)
+  }
 
   private[packaging] val emptyFeaturesXml = FeaturesXml(null, Seq.empty)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -57,7 +57,7 @@ object OsgiToolingBuild extends Build {
 
   val commonSettings = Seq(
     organization in ThisBuild := "wav.devtools",
-    version := "0.1.2.PHILIP",
+    version := "0.1.3.PHILIP",
     publishLocalConfiguration ~= { conf =>
       new PublishConfiguration(conf.ivyFile, conf.resolverName, conf.artifacts, conf.checksums, conf.logging, true)
     },

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -57,7 +57,7 @@ object OsgiToolingBuild extends Build {
 
   val commonSettings = Seq(
     organization in ThisBuild := "wav.devtools",
-    version := "0.1.0.SNAPSHOT",
+    version := "0.1.1.PHILIP",
     publishLocalConfiguration ~= { conf =>
       new PublishConfiguration(conf.ivyFile, conf.resolverName, conf.artifacts, conf.checksums, conf.logging, true)
     },

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -57,7 +57,7 @@ object OsgiToolingBuild extends Build {
 
   val commonSettings = Seq(
     organization in ThisBuild := "wav.devtools",
-    version := "0.1.1.PHILIP",
+    version := "0.1.2.PHILIP",
     publishLocalConfiguration ~= { conf =>
       new PublishConfiguration(conf.ivyFile, conf.resolverName, conf.artifacts, conf.checksums, conf.logging, true)
     },


### PR DESCRIPTION
When running sbt featuresFile, getMainAttributes.getValue("Bundle-SymbolicName") returns null for some input. Protect against null by not throwing an exception. Suitable here or should we also make a warning message? Its not fun to have a crash on a build.
